### PR TITLE
Re-implement dropdown in a way it works independently from antd

### DIFF
--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,5 +1,5 @@
-import React, { CSSProperties, MouseEventHandler, useState } from "react";
-import Tool, { ToolConfig } from "../enums/Tool";
+import React, { useState } from "react";
+import { ToolConfig } from "../enums/Tool";
 
 type Props = {
   tool: ToolConfig;
@@ -15,9 +15,9 @@ function Dropdown(props: Props) {
   const { children, overlay, isCurrent } = props;
   const [isDropdownVisible, setDropdownVisible] = useState(false);
 
-  const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
+  const stopPropagation: any = (e) => e.stopPropagation();
 
-  const menuStyle: CSSProperties = {
+  const menuStyle: any = {
     position: 'absolute',
     top: 56,
   };
@@ -39,8 +39,6 @@ function Dropdown(props: Props) {
     </div>
 
   );
-  // if (!visible) return null;
-  // return <div onClick={onVisibleChange}>{overlay}</div>;
 }
 
 export { Dropdown };

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,13 +1,13 @@
 import React, { CSSProperties, MouseEventHandler, useState } from "react";
-import { ToolConfig } from "../enums/Tool";
+// import { ToolConfig } from "../enums/Tool";
 
 type Props = {
-  tool: ToolConfig;
-  key: string;
-  overlay: JSX.Element;
-  trigger: Array<'click' | 'hover'>;
-  isCurrent: boolean;
-  children: React.Component | Array<React.Component>;
+  tool: any;
+  key: any;
+  overlay: any;
+  trigger: any;
+  isCurrent: any;
+  children: any;
 };
 
 function Dropdown(props: Props) {

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,13 +1,13 @@
 import React, { CSSProperties, MouseEventHandler, useState } from "react";
-// import { ToolConfig } from "../enums/Tool";
+import { ToolConfig } from "../enums/Tool";
 
 type Props = {
-  tool: any;
-  key: any;
-  overlay: any;
-  trigger: any;
-  isCurrent: any;
-  children: any;
+  tool: ToolConfig;
+  key: string;
+  overlay: JSX.Element;
+  trigger: Array<'click' | 'hover'>;
+  isCurrent: boolean;
+  children: JSX.Element | Array<JSX.Element>;
 };
 
 function Dropdown(props: Props) {

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,34 +1,38 @@
-import React from "react";
+import React, { CSSProperties, MouseEventHandler } from "react";
+// import Tool, { ToolOption, defaultToolOption } from '../enums/Tool';
+// import { useStrokeDropdown } from "../StrokeTool";
 
 function Dropdown(props: any) {
   console.log('DROPDOWN', props);
-  // let settingMenu = null;
-  // let content = null;
-  // const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
+  const { children, overlay, isVisible, setVisible } = props;
+  function toggleVisibility() {
+    setVisible(!isVisible);
+  }
+
+  let settingMenu = null;
+  let content = null;
+  const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
 
   //   switch (selectedOperation.tool) {
   //     case Tool.Stroke:
-  //       content = useStrokeDropdown({
-  //         currentToolOption: {
-  //           strokeSize: (selectedOperation as Stroke).size,
-  //           strokeColor: (selectedOperation as Stroke).color,
-  //         } as ToolOption,
-  //         setCurrentToolOption: (option: ToolOption) => {
-  //           const data = {
-  //             color: option.strokeColor,
-  //             size: option.strokeSize,
-  //           };
+        // content = useStrokeDropdown({
+        //   currentToolOption: defaultToolOption,
+        //   setCurrentToolOption: (option: ToolOption) => {
+        //     const data = {
+        //       color: option.strokeColor,
+        //       size: option.strokeSize,
+        //     };
 
-  //           handleCompleteOperation(Tool.Update, {
-  //             operationId: selectedOperation.id,
-  //             data,
-  //           });
+        //     handleCompleteOperation(Tool.Update, {
+        //       operationId: selectedOperation.id,
+        //       data,
+        //     });
 
-  //           setSelectedOperation({ ...selectedOperation, ...data });
-  //         },
-  //         setCurrentTool: () => {},
-  //         prefixCls,
-  //       });
+        //     setSelectedOperation({ ...selectedOperation, ...data });
+        //   },
+        //   setCurrentTool: () => {},
+        //   prefixCls,
+        // });
   //       break;
   //     case Tool.Shape:
   //       content = useShapeDropdown({
@@ -101,31 +105,45 @@ function Dropdown(props: any) {
   //       break;
   //   }
 
-  //   // const resultRect = {
-  //   //   xMin: selectedOperation.pos.x,
-  //   //   xMax: selectedOperation.pos.x + selectedOperation.pos.w,
-  //   //   yMin: selectedOperation.pos.y,
-  //   //   yMax: selectedOperation.pos.y + selectedOperation.pos.h,
-  //   // };
+  // const resultRect = {
+  //   xMin: 10,
+  //   xMax: 10 + 600,
+  //   yMin: 200,
+  //   yMax: 200 + 600,
+  // };
 
-  //   // const [a, b, c, d, e, f] = viewMatrix;
-  //   // const selectPadding = Math.max((SELECT_PADDING * 1) / scale || 0, SELECT_PADDING);
-  //   // const left = resultRect.xMin;
-  //   // const top = resultRect.yMax + selectPadding;
+  // const [a, b, c, d, e, f] = viewMatrix;
+  // const selectPadding = Math.max((SELECT_PADDING * 1) / scale || 0, SELECT_PADDING);
+  // const left = resultRect.xMin;
+  // const top = resultRect.yMax + selectPadding;
 
-  //   const menuStyle: CSSProperties = {
-  //     position: 'absolute',
-  //     left: a * left + c * top + e,
-  //     top: b * left + d * top + f,
-  //   };
+  const menuStyle: CSSProperties = {
+    position: 'absolute',
+    top: 150,
+    left: 0,
+    // left: a * left + c * top + e,
+    // top: b * left + d * top + f,
+  };
 
-  //   settingMenu = (
-  //     <div style={menuStyle} onMouseDown={stopPropagation}>
-  //       {content}
-  //     </div>
-  //   );
+  settingMenu = (
+    <div style={menuStyle} onMouseDown={stopPropagation}>
+      {/* {content} */}
+      {overlay}
+    </div>
+  );
 
-  return <div>{props.children}</div>;
+  return (
+    <div
+      style={{backgroundColor: 'rgba(255,0,0,0.3)', position: 'relative'}}
+      onClick={toggleVisibility}
+    >
+      {children}
+      {isVisible ? settingMenu : null}
+    </div>
+
+  );
+  // if (!visible) return null;
+  // return <div onClick={onVisibleChange}>{overlay}</div>;
 }
 
 export { Dropdown };

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -4,10 +4,10 @@ import React, { CSSProperties, MouseEventHandler } from "react";
 
 function Dropdown(props: any) {
   console.log('DROPDOWN', props);
-  const { children, overlay, isVisible, setVisible } = props;
-  function toggleVisibility() {
-    setVisible(!isVisible);
-  }
+  const { children, overlay, isVisible } = props;
+  // function toggleVisibility() {
+  //   setVisible(!isVisible);
+  // }
 
   let settingMenu = null;
   let content = null;
@@ -135,7 +135,7 @@ function Dropdown(props: any) {
   return (
     <div
       style={{backgroundColor: 'rgba(255,0,0,0.3)', position: 'relative'}}
-      onClick={toggleVisibility}
+      // onClick={toggleVisibility}
     >
       {children}
       {isVisible ? settingMenu : null}

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -10,6 +10,8 @@ function Dropdown(props: Props) {
   const { children, overlay, key } = props;
   const [isDropdownVisible, setDropdownVisible] = useState(false);
 
+  // This code will prevent accidentally drawing under the dropdown when you are
+  // selecting an item from the tool options
   const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
 
   const menuStyle: CSSProperties = {

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,18 +1,13 @@
 import React, { CSSProperties, MouseEventHandler, useState } from "react";
-import { ToolConfig } from "../enums/Tool";
 
 type Props = {
-  tool: ToolConfig;
   key: string;
   overlay: JSX.Element;
-  trigger: Array<'click' | 'hover'>;
-  isCurrent: boolean;
   children: JSX.Element | Array<JSX.Element>;
 };
 
 function Dropdown(props: Props) {
-  console.log('DROPDOWN', props);
-  const { children, overlay, isCurrent } = props;
+  const { children, overlay, key } = props;
   const [isDropdownVisible, setDropdownVisible] = useState(false);
 
   const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
@@ -32,6 +27,7 @@ function Dropdown(props: Props) {
 
   return (
     <div
+      key={key}
       style={wrapperStyle}
       onMouseEnter={() => setDropdownVisible(true)}
       onMouseLeave={() => setDropdownVisible(false)}

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,6 +1,130 @@
 import React from "react";
 
 function Dropdown(props: any) {
+  console.log('DROPDOWN', props);
+  // let settingMenu = null;
+  // let content = null;
+  // const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
+
+  //   switch (selectedOperation.tool) {
+  //     case Tool.Stroke:
+  //       content = useStrokeDropdown({
+  //         currentToolOption: {
+  //           strokeSize: (selectedOperation as Stroke).size,
+  //           strokeColor: (selectedOperation as Stroke).color,
+  //         } as ToolOption,
+  //         setCurrentToolOption: (option: ToolOption) => {
+  //           const data = {
+  //             color: option.strokeColor,
+  //             size: option.strokeSize,
+  //           };
+
+  //           handleCompleteOperation(Tool.Update, {
+  //             operationId: selectedOperation.id,
+  //             data,
+  //           });
+
+  //           setSelectedOperation({ ...selectedOperation, ...data });
+  //         },
+  //         setCurrentTool: () => {},
+  //         prefixCls,
+  //       });
+  //       break;
+  //     case Tool.Shape:
+  //       content = useShapeDropdown({
+  //         currentToolOption: {
+  //           shapeType: (selectedOperation as Shape).type,
+  //           shapeBorderColor: (selectedOperation as Shape).color,
+  //           shapeBorderSize: (selectedOperation as Shape).size,
+  //         } as ToolOption,
+  //         setCurrentToolOption: (option: ToolOption) => {
+  //           const data = {
+  //             type: option.shapeType,
+  //             color: option.shapeBorderColor,
+  //             size: option.shapeBorderSize,
+  //           };
+
+  //           handleCompleteOperation(Tool.Update, {
+  //             operationId: selectedOperation.id,
+  //             data,
+  //           });
+
+  //           setSelectedOperation({ ...selectedOperation, ...data });
+  //         },
+  //         setCurrentTool: () => {},
+  //         prefixCls,
+  //       });
+  //       break;
+  //     case Tool.Text: {
+  //       const textOperation: Text = selectedOperation as Text;
+  //       content = useTextDropdown(
+  //         {
+  //           textSize: textOperation.size,
+  //           textColor: textOperation.color,
+  //         } as ToolOption,
+  //         (option: ToolOption) => {
+  //           const data: Partial<Operation> = {
+  //             color: option.textColor,
+  //             size: option.textSize,
+  //           };
+
+  //           if (refContext.current && option.textSize !== textOperation.size) {
+  //             const context = refContext.current;
+
+  //             // font size has changed, need to update pos
+  //             context.font = `${option.textSize}px ${font}`;
+  //             context.textBaseline = 'alphabetic';
+  //             // measureText does not support multi-line
+  //             const lines = textOperation.text.split('\n');
+  //             data.pos = {
+  //               ...selectedOperation.pos,
+  //               w: Math.max(...lines.map((line) => context.measureText(line).width)),
+  //               h: lines.length * option.textSize,
+  //             };
+  //           }
+
+  //           handleCompleteOperation(Tool.Update, {
+  //             operationId: selectedOperation.id,
+  //             data,
+  //           });
+
+  //           // @ts-ignore
+  //           setSelectedOperation({ ...selectedOperation, ...data });
+  //         },
+  //         () => {},
+  //         intl,
+  //         prefixCls,
+  //       );
+  //       break;
+  //     }
+  //     default:
+  //       break;
+  //   }
+
+  //   // const resultRect = {
+  //   //   xMin: selectedOperation.pos.x,
+  //   //   xMax: selectedOperation.pos.x + selectedOperation.pos.w,
+  //   //   yMin: selectedOperation.pos.y,
+  //   //   yMax: selectedOperation.pos.y + selectedOperation.pos.h,
+  //   // };
+
+  //   // const [a, b, c, d, e, f] = viewMatrix;
+  //   // const selectPadding = Math.max((SELECT_PADDING * 1) / scale || 0, SELECT_PADDING);
+  //   // const left = resultRect.xMin;
+  //   // const top = resultRect.yMax + selectPadding;
+
+  //   const menuStyle: CSSProperties = {
+  //     position: 'absolute',
+  //     left: a * left + c * top + e,
+  //     top: b * left + d * top + f,
+  //   };
+
+  //   settingMenu = (
+  //     <div style={menuStyle} onMouseDown={stopPropagation}>
+  //       {content}
+  //     </div>
+  //   );
+
   return <div>{props.children}</div>;
 }
 

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,23 +1,23 @@
-import React, { useState } from "react";
+import React, { CSSProperties, MouseEventHandler, useState } from "react";
 import { ToolConfig } from "../enums/Tool";
 
 type Props = {
-  tool: any;
-  key: any;
-  overlay: any;
-  trigger: any;
-  isCurrent: any;
-  children: any;
+  tool: ToolConfig;
+  key: string;
+  overlay: JSX.Element;
+  trigger: Array<'click' | 'hover'>;
+  isCurrent: boolean;
+  children: React.Component | Array<React.Component>;
 };
 
-function Dropdown(props: any) {
+function Dropdown(props: Props) {
   console.log('DROPDOWN', props);
   const { children, overlay, isCurrent } = props;
   const [isDropdownVisible, setDropdownVisible] = useState(false);
 
-  const stopPropagation: any = (e: any) => e.stopPropagation();
+  const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
 
-  const menuStyle: any = {
+  const menuStyle: CSSProperties = {
     position: 'absolute',
     top: 56,
   };
@@ -28,7 +28,7 @@ function Dropdown(props: any) {
     </div>
   );
 
-  const wrapperStyle: any = {position: 'relative'};
+  const wrapperStyle: CSSProperties = { position: 'relative' };
 
   return (
     <div

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,144 +1,41 @@
-import React, { CSSProperties, MouseEventHandler } from "react";
-// import Tool, { ToolOption, defaultToolOption } from '../enums/Tool';
-// import { useStrokeDropdown } from "../StrokeTool";
+import React, { CSSProperties, MouseEventHandler, useState } from "react";
+import Tool, { ToolConfig } from "../enums/Tool";
 
-function Dropdown(props: any) {
+type Props = {
+  tool: ToolConfig;
+  key: string;
+  overlay: JSX.Element;
+  trigger: 'click' | 'hover';
+  isCurrent: boolean;
+  children: React.Component | Array<React.Component>;
+};
+
+function Dropdown(props: Props) {
   console.log('DROPDOWN', props);
-  const { children, overlay, isVisible } = props;
-  // function toggleVisibility() {
-  //   setVisible(!isVisible);
-  // }
+  const { children, overlay, isCurrent } = props;
+  const [isDropdownVisible, setDropdownVisible] = useState(false);
 
-  let settingMenu = null;
-  let content = null;
   const stopPropagation: MouseEventHandler = (e) => e.stopPropagation();
-
-  //   switch (selectedOperation.tool) {
-  //     case Tool.Stroke:
-        // content = useStrokeDropdown({
-        //   currentToolOption: defaultToolOption,
-        //   setCurrentToolOption: (option: ToolOption) => {
-        //     const data = {
-        //       color: option.strokeColor,
-        //       size: option.strokeSize,
-        //     };
-
-        //     handleCompleteOperation(Tool.Update, {
-        //       operationId: selectedOperation.id,
-        //       data,
-        //     });
-
-        //     setSelectedOperation({ ...selectedOperation, ...data });
-        //   },
-        //   setCurrentTool: () => {},
-        //   prefixCls,
-        // });
-  //       break;
-  //     case Tool.Shape:
-  //       content = useShapeDropdown({
-  //         currentToolOption: {
-  //           shapeType: (selectedOperation as Shape).type,
-  //           shapeBorderColor: (selectedOperation as Shape).color,
-  //           shapeBorderSize: (selectedOperation as Shape).size,
-  //         } as ToolOption,
-  //         setCurrentToolOption: (option: ToolOption) => {
-  //           const data = {
-  //             type: option.shapeType,
-  //             color: option.shapeBorderColor,
-  //             size: option.shapeBorderSize,
-  //           };
-
-  //           handleCompleteOperation(Tool.Update, {
-  //             operationId: selectedOperation.id,
-  //             data,
-  //           });
-
-  //           setSelectedOperation({ ...selectedOperation, ...data });
-  //         },
-  //         setCurrentTool: () => {},
-  //         prefixCls,
-  //       });
-  //       break;
-  //     case Tool.Text: {
-  //       const textOperation: Text = selectedOperation as Text;
-  //       content = useTextDropdown(
-  //         {
-  //           textSize: textOperation.size,
-  //           textColor: textOperation.color,
-  //         } as ToolOption,
-  //         (option: ToolOption) => {
-  //           const data: Partial<Operation> = {
-  //             color: option.textColor,
-  //             size: option.textSize,
-  //           };
-
-  //           if (refContext.current && option.textSize !== textOperation.size) {
-  //             const context = refContext.current;
-
-  //             // font size has changed, need to update pos
-  //             context.font = `${option.textSize}px ${font}`;
-  //             context.textBaseline = 'alphabetic';
-  //             // measureText does not support multi-line
-  //             const lines = textOperation.text.split('\n');
-  //             data.pos = {
-  //               ...selectedOperation.pos,
-  //               w: Math.max(...lines.map((line) => context.measureText(line).width)),
-  //               h: lines.length * option.textSize,
-  //             };
-  //           }
-
-  //           handleCompleteOperation(Tool.Update, {
-  //             operationId: selectedOperation.id,
-  //             data,
-  //           });
-
-  //           // @ts-ignore
-  //           setSelectedOperation({ ...selectedOperation, ...data });
-  //         },
-  //         () => {},
-  //         intl,
-  //         prefixCls,
-  //       );
-  //       break;
-  //     }
-  //     default:
-  //       break;
-  //   }
-
-  // const resultRect = {
-  //   xMin: 10,
-  //   xMax: 10 + 600,
-  //   yMin: 200,
-  //   yMax: 200 + 600,
-  // };
-
-  // const [a, b, c, d, e, f] = viewMatrix;
-  // const selectPadding = Math.max((SELECT_PADDING * 1) / scale || 0, SELECT_PADDING);
-  // const left = resultRect.xMin;
-  // const top = resultRect.yMax + selectPadding;
 
   const menuStyle: CSSProperties = {
     position: 'absolute',
-    top: 150,
-    left: 0,
-    // left: a * left + c * top + e,
-    // top: b * left + d * top + f,
+    top: 56,
   };
 
-  settingMenu = (
+  const settingMenu = (
     <div style={menuStyle} onMouseDown={stopPropagation}>
-      {/* {content} */}
       {overlay}
     </div>
   );
 
   return (
     <div
-      style={{backgroundColor: 'rgba(255,0,0,0.3)', position: 'relative'}}
-      // onClick={toggleVisibility}
+      style={{position: 'relative'}}
+      onMouseEnter={() => setDropdownVisible(true)}
+      onMouseLeave={() => setDropdownVisible(false)}
     >
       {children}
-      {isVisible ? settingMenu : null}
+      {isDropdownVisible ? settingMenu : null}
     </div>
 
   );

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -2,20 +2,20 @@ import React, { useState } from "react";
 import { ToolConfig } from "../enums/Tool";
 
 type Props = {
-  tool: ToolConfig;
-  key: string;
-  overlay: JSX.Element;
-  trigger: 'click' | 'hover';
-  isCurrent: boolean;
-  children: React.Component | Array<React.Component>;
+  tool: any;
+  key: any;
+  overlay: any;
+  trigger: any;
+  isCurrent: any;
+  children: any;
 };
 
-function Dropdown(props: Props) {
+function Dropdown(props: any) {
   console.log('DROPDOWN', props);
   const { children, overlay, isCurrent } = props;
   const [isDropdownVisible, setDropdownVisible] = useState(false);
 
-  const stopPropagation: any = (e) => e.stopPropagation();
+  const stopPropagation: any = (e: any) => e.stopPropagation();
 
   const menuStyle: any = {
     position: 'absolute',
@@ -28,9 +28,11 @@ function Dropdown(props: Props) {
     </div>
   );
 
+  const wrapperStyle: any = {position: 'relative'};
+
   return (
     <div
-      style={{position: 'relative'}}
+      style={wrapperStyle}
       onMouseEnter={() => setDropdownVisible(true)}
       onMouseLeave={() => setDropdownVisible(false)}
     >

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, ChangeEventHandler, useContext, useMemo } from 'react';
 import { useSpring, animated } from 'react-spring';
 import { useIntl } from 'react-intl';
-import Tool, { ToolConfig, ToolOption } from './enums/Tool';
+import Tool, { ToolOption } from './enums/Tool';
 import SelectIcon from './svgs/SelectIcon';
 import StrokeIcon from './svgs/StrokeIcon';
 import ShapeIcon from './svgs/ShapeIcon';
@@ -24,21 +24,21 @@ import { isMobileDevice } from './utils';
 import ConfigContext from './ConfigContext';
 import EnableSketchPadContext from './contexts/EnableSketchPadContext';
 
-export type ToolbarProps = {
-  currentTool: Tool;
-  setCurrentTool: (tool: Tool) => void;
-  currentToolOption: ToolOption;
-  setCurrentToolOption: (option: ToolOption) => void;
-  selectImage: (image: string) => void;
-  selectBackgroundImage: (image: string) => void;
-  removeBackgroundImage: () => void;
-  undo: () => void;
-  redo: () => void;
-  clear: () => void;
-  save: () => void;
-  scale: number;
-  toolbarPlacement: string;
-};
+interface ToolConfig {
+  label: string;
+  icon: React.FC;
+  type: Tool;
+  labelThunk?: (props: ToolbarProps) => string;
+  useDropdown?: (config: {
+    currentToolOption: ToolOption;
+    setCurrentToolOption: (option: ToolOption) => void;
+    setCurrentTool: (tool: Tool) => void;
+    prefixCls: string;
+    selectBackgroundImage: () => void;
+    removeBackgroundImage: () => void;
+  }) => JSX.Element;
+  style?: React.CSSProperties;
+}
 
 const useTools = () => {
   const { showBackgroundTool } = useContext(ConfigContext);
@@ -132,6 +132,22 @@ const useTools = () => {
 
   return tools;
 };
+
+interface ToolbarProps {
+  currentTool: Tool;
+  setCurrentTool: (tool: Tool) => void;
+  currentToolOption: ToolOption;
+  setCurrentToolOption: (option: ToolOption) => void;
+  selectImage: (image: string) => void;
+  selectBackgroundImage: (image: string) => void;
+  removeBackgroundImage: () => void;
+  undo: () => void;
+  redo: () => void;
+  clear: () => void;
+  save: () => void;
+  scale: number;
+  toolbarPlacement: string;
+}
 
 const Toolbar: React.FC<ToolbarProps> = (props) => {
   const {

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -177,16 +177,16 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       const file = e.target.files && e.target.files[0];
       e.target.value = '';
 
-    if (file) {
-      let reader = new FileReader();
-      reader.readAsDataURL(file);
-      reader.onloadend = () => {
-        const base64data = reader.result;
+      if (file) {
+        let reader = new FileReader();
+        reader.readAsDataURL(file);
+        reader.onloadend = () => {
+          const base64data = reader.result;
 
-        cb(base64data as string);
-      };
-    }
-  };
+          cb(base64data as string);
+        };
+      }
+    };
 
   const handleSelectImage = handleFileChange(selectImage);
 

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -49,29 +49,29 @@ const useTools = () => {
         label: 'umi.block.sketch.select',
         icon: SelectIcon,
         type: Tool.Select,
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.pencil',
         icon: StrokeIcon,
         type: Tool.Stroke,
         useDropdown: useStrokeDropdown,
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.shape',
         icon: ShapeIcon,
         type: Tool.Shape,
         useDropdown: useShapeDropdown,
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.text',
         icon: TextIcon,
         type: Tool.Text,
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.image',
         icon: ImageIcon,
         type: Tool.Image,
-      } as ToolConfig,
+      },
       ...(showBackgroundTool
         ? [
             {
@@ -79,7 +79,7 @@ const useTools = () => {
               icon: BackgroundIcon,
               type: Tool.Background,
               useDropdown: useBackgroundDropdown,
-            } as ToolConfig,
+            },
           ]
         : []),
       {
@@ -89,17 +89,17 @@ const useTools = () => {
         style: {
           marginLeft: 'auto',
         },
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.redo',
         icon: RedoIcon,
         type: Tool.Redo,
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.eraser',
         icon: EraserIcon,
         type: Tool.Eraser,
-      } as ToolConfig,
+      },
       {
         label: 'umi.block.sketch.clear',
         icon: ClearIcon,
@@ -107,7 +107,7 @@ const useTools = () => {
         style: {
           marginRight: 'auto',
         },
-      } as ToolConfig,
+      },
       ...(!isMobileDevice
         ? [
             {
@@ -115,7 +115,7 @@ const useTools = () => {
               labelThunk: (props: ToolbarProps) => `${~~(props.scale * 100)}%`,
               icon: ZoomIcon,
               type: Tool.Zoom,
-            } as ToolConfig,
+            },
           ]
         : []),
       ...(!isMobileDevice
@@ -124,7 +124,7 @@ const useTools = () => {
               label: 'umi.block.sketch.save',
               icon: SaveIcon,
               type: Tool.Save,
-            } as ToolConfig,
+            },
           ]
         : []),
     ];

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, ChangeEventHandler, useContext, useMemo } from 'react';
 import { useSpring, animated } from 'react-spring';
 import { useIntl } from 'react-intl';
-import Tool, { ToolOption, ToolConfig, ToolbarProps } from './enums/Tool';
+import Tool, { ToolConfig, ToolOption } from './enums/Tool';
 import SelectIcon from './svgs/SelectIcon';
 import StrokeIcon from './svgs/StrokeIcon';
 import ShapeIcon from './svgs/ShapeIcon';
@@ -23,6 +23,22 @@ import './Toolbar.less';
 import { isMobileDevice } from './utils';
 import ConfigContext from './ConfigContext';
 import EnableSketchPadContext from './contexts/EnableSketchPadContext';
+
+export type ToolbarProps = {
+  currentTool: Tool;
+  setCurrentTool: (tool: Tool) => void;
+  currentToolOption: ToolOption;
+  setCurrentToolOption: (option: ToolOption) => void;
+  selectImage: (image: string) => void;
+  selectBackgroundImage: (image: string) => void;
+  removeBackgroundImage: () => void;
+  undo: () => void;
+  redo: () => void;
+  clear: () => void;
+  save: () => void;
+  scale: number;
+  toolbarPlacement: string;
+};
 
 const useTools = () => {
   const { showBackgroundTool } = useContext(ConfigContext);

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -262,6 +262,12 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
             setCurrentToolOption,
             setCurrentTool,
             prefixCls,
+            selectBackgroundImage: () => {
+              refBgFileInput.current.click();
+            },
+            removeBackgroundImage: () => {
+              removeBackgroundImage();
+            },
           });
 
           return (

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -239,7 +239,6 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
                 clear();
               } else if (tool.type === Tool.Zoom) {
               } else if (tool.type === Tool.Save) {
-                enableSketchPadContext.setEnable(false);
                 save();
               } else {
                 setCurrentTool(tool.type);

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -13,8 +13,10 @@ import ClearIcon from './svgs/ClearIcon';
 import ZoomIcon from './svgs/ZoomIcon';
 import SaveIcon from './svgs/SaveIcon';
 import EraserIcon from './svgs/EraserIcon';
+import BackgroundIcon from './svgs/BackgroundIcon';
 import { useStrokeDropdown } from './StrokeTool';
 import { useShapeDropdown } from './ShapeTool';
+import { useBackgroundDropdown } from './BackgroundTool';
 import { Dropdown } from './Layout';
 import classNames from 'classnames';
 import './Toolbar.less';
@@ -47,29 +49,29 @@ const useTools = () => {
         label: 'umi.block.sketch.select',
         icon: SelectIcon,
         type: Tool.Select,
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.pencil',
         icon: StrokeIcon,
         type: Tool.Stroke,
         useDropdown: useStrokeDropdown,
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.shape',
         icon: ShapeIcon,
         type: Tool.Shape,
         useDropdown: useShapeDropdown,
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.text',
         icon: TextIcon,
         type: Tool.Text,
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.image',
         icon: ImageIcon,
         type: Tool.Image,
-      },
+      } as ToolConfig,
       ...(showBackgroundTool
         ? [
             {
@@ -77,7 +79,7 @@ const useTools = () => {
               icon: BackgroundIcon,
               type: Tool.Background,
               useDropdown: useBackgroundDropdown,
-            },
+            } as ToolConfig,
           ]
         : []),
       {
@@ -87,17 +89,17 @@ const useTools = () => {
         style: {
           marginLeft: 'auto',
         },
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.redo',
         icon: RedoIcon,
         type: Tool.Redo,
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.eraser',
         icon: EraserIcon,
         type: Tool.Eraser,
-      },
+      } as ToolConfig,
       {
         label: 'umi.block.sketch.clear',
         icon: ClearIcon,
@@ -105,7 +107,7 @@ const useTools = () => {
         style: {
           marginRight: 'auto',
         },
-      },
+      } as ToolConfig,
       ...(!isMobileDevice
         ? [
             {
@@ -113,7 +115,7 @@ const useTools = () => {
               labelThunk: (props: ToolbarProps) => `${~~(props.scale * 100)}%`,
               icon: ZoomIcon,
               type: Tool.Zoom,
-            },
+            } as ToolConfig,
           ]
         : []),
       ...(!isMobileDevice
@@ -122,7 +124,7 @@ const useTools = () => {
               label: 'umi.block.sketch.save',
               icon: SaveIcon,
               type: Tool.Save,
-            },
+            } as ToolConfig,
           ]
         : []),
     ];
@@ -265,15 +267,9 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
             <Dropdown
               key={tool.label}
               overlay={overlay}
-              placement={
-                toolbarPlacement === 'top' || toolbarPlacement === 'left'
-                  ? 'bottomLeft'
-                  : 'bottomRight'
-              }
-              trigger={[isMobileDevice ? 'click' : 'hover']}
-              onVisibleChange={(visible) => {
-                enableSketchPadContext.setEnable(!visible);
-              }}
+              trigger={['hover']}
+              setVisible={enableSketchPadContext.setEnable}
+              isVisible={enableSketchPadContext.enable}
             >
               {menu}
             </Dropdown>

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, ChangeEventHandler, useContext, useMemo } from 'react';
 import { useSpring, animated } from 'react-spring';
 import { useIntl } from 'react-intl';
-import Tool, { ToolOption } from './enums/Tool';
+import Tool, { ToolOption, ToolConfig, ToolbarProps } from './enums/Tool';
 import SelectIcon from './svgs/SelectIcon';
 import StrokeIcon from './svgs/StrokeIcon';
 import ShapeIcon from './svgs/ShapeIcon';
@@ -23,22 +23,6 @@ import './Toolbar.less';
 import { isMobileDevice } from './utils';
 import ConfigContext from './ConfigContext';
 import EnableSketchPadContext from './contexts/EnableSketchPadContext';
-
-interface ToolConfig {
-  label: string;
-  icon: React.FC;
-  type: Tool;
-  labelThunk?: (props: ToolbarProps) => string;
-  useDropdown?: (config: {
-    currentToolOption: ToolOption;
-    setCurrentToolOption: (option: ToolOption) => void;
-    setCurrentTool: (tool: Tool) => void;
-    prefixCls: string;
-    selectBackgroundImage?: () => void;
-    removeBackgroundImage?: () => void;
-  }) => JSX.Element;
-  style?: React.CSSProperties;
-}
 
 const useTools = () => {
   const { showBackgroundTool } = useContext(ConfigContext);
@@ -133,22 +117,6 @@ const useTools = () => {
   return tools;
 };
 
-export interface ToolbarProps {
-  currentTool: Tool;
-  setCurrentTool: (tool: Tool) => void;
-  currentToolOption: ToolOption;
-  setCurrentToolOption: (option: ToolOption) => void;
-  selectImage: (image: string) => void;
-  selectBackgroundImage: (image: string) => void;
-  removeBackgroundImage: () => void;
-  undo: () => void;
-  redo: () => void;
-  clear: () => void;
-  save: () => void;
-  scale: number;
-  toolbarPlacement: string;
-}
-
 const Toolbar: React.FC<ToolbarProps> = (props) => {
   const {
     currentTool,
@@ -239,6 +207,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
                 clear();
               } else if (tool.type === Tool.Zoom) {
               } else if (tool.type === Tool.Save) {
+                enableSketchPadContext.setEnable(false);
                 save();
               } else {
                 setCurrentTool(tool.type);
@@ -265,10 +234,11 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
 
           return (
             <Dropdown
+              tool={tool}
               key={tool.label}
               overlay={overlay}
-              trigger={['hover']}
-              isVisible={currentTool === tool.type}
+              trigger={[isMobileDevice ? 'click' : 'hover']}
+              isCurrent={currentTool === tool.type}
             >
               {menu}
             </Dropdown>

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -13,10 +13,8 @@ import ClearIcon from './svgs/ClearIcon';
 import ZoomIcon from './svgs/ZoomIcon';
 import SaveIcon from './svgs/SaveIcon';
 import EraserIcon from './svgs/EraserIcon';
-import BackgroundIcon from './svgs/BackgroundIcon';
 import { useStrokeDropdown } from './StrokeTool';
 import { useShapeDropdown } from './ShapeTool';
-import { useBackgroundDropdown } from './BackgroundTool';
 import { Dropdown } from './Layout';
 import classNames from 'classnames';
 import './Toolbar.less';
@@ -34,8 +32,8 @@ interface ToolConfig {
     setCurrentToolOption: (option: ToolOption) => void;
     setCurrentTool: (tool: Tool) => void;
     prefixCls: string;
-    selectBackgroundImage: () => void;
-    removeBackgroundImage: () => void;
+    selectBackgroundImage?: () => void;
+    removeBackgroundImage?: () => void;
   }) => JSX.Element;
   style?: React.CSSProperties;
 }
@@ -177,16 +175,16 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
       const file = e.target.files && e.target.files[0];
       e.target.value = '';
 
-      if (file) {
-        let reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onloadend = () => {
-          const base64data = reader.result;
+    if (file) {
+      let reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onloadend = () => {
+        const base64data = reader.result;
 
-          cb(base64data as string);
-        };
-      }
-    };
+        cb(base64data as string);
+      };
+    }
+  };
 
   const handleSelectImage = handleFileChange(selectImage);
 
@@ -255,7 +253,34 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
           </animated.div>
         );
 
-        return menu;
+        if (tool.useDropdown) {
+          const overlay = tool.useDropdown({
+            currentToolOption,
+            setCurrentToolOption,
+            setCurrentTool,
+            prefixCls,
+          });
+
+          return (
+            <Dropdown
+              key={tool.label}
+              overlay={overlay}
+              placement={
+                toolbarPlacement === 'top' || toolbarPlacement === 'left'
+                  ? 'bottomLeft'
+                  : 'bottomRight'
+              }
+              trigger={[isMobileDevice ? 'click' : 'hover']}
+              onVisibleChange={(visible) => {
+                enableSketchPadContext.setEnable(!visible);
+              }}
+            >
+              {menu}
+            </Dropdown>
+          );
+        } else {
+          return menu;
+        }
       })}
 
       <input

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -268,8 +268,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
               key={tool.label}
               overlay={overlay}
               trigger={['hover']}
-              setVisible={enableSketchPadContext.setEnable}
-              isVisible={enableSketchPadContext.enable}
+              isVisible={currentTool === tool.type}
             >
               {menu}
             </Dropdown>

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -249,15 +249,7 @@ const Toolbar: React.FC<ToolbarProps> = (props) => {
           });
 
           return (
-            <Dropdown
-              tool={tool}
-              key={tool.label}
-              overlay={overlay}
-              trigger={[isMobileDevice ? 'click' : 'hover']}
-              isCurrent={currentTool === tool.type}
-            >
-              {menu}
-            </Dropdown>
+            <Dropdown key={tool.label} overlay={overlay}>{menu}</Dropdown>
           );
         } else {
           return menu;

--- a/src/enums/Tool.ts
+++ b/src/enums/Tool.ts
@@ -33,7 +33,7 @@ export interface Position {
   h: number;
 }
 
-export const strokeSize = [2, 4, 6];
+export const strokeSize = [2, 4, 6, 9];
 
 export const strokeColor = [
   '#4a4a4a',

--- a/src/enums/Tool.ts
+++ b/src/enums/Tool.ts
@@ -33,7 +33,7 @@ export interface Position {
   h: number;
 }
 
-export const strokeSize = [2, 4, 6, 9];
+export const strokeSize = [2, 4, 6];
 
 export const strokeColor = [
   '#4a4a4a',

--- a/src/enums/Tool.ts
+++ b/src/enums/Tool.ts
@@ -81,20 +81,4 @@ export type ToolOption = {
       };
 };
 
-export type ToolConfig = {
-  label: string;
-  icon: React.FC;
-  type: Tool;
-  labelThunk?: (props: { scale: number }) => string;
-  useDropdown?: (config: {
-    currentToolOption: ToolOption;
-    setCurrentToolOption: (option: ToolOption) => void;
-    setCurrentTool: (tool: Tool) => void;
-    prefixCls: string;
-    selectBackgroundImage?: () => void;
-    removeBackgroundImage?: () => void;
-  }) => JSX.Element;
-  style?: React.CSSProperties;
-}
-
 export default Tool;

--- a/src/enums/Tool.ts
+++ b/src/enums/Tool.ts
@@ -81,27 +81,11 @@ export type ToolOption = {
       };
 };
 
-export type ToolbarProps = {
-  currentTool: Tool;
-  setCurrentTool: (tool: Tool) => void;
-  currentToolOption: ToolOption;
-  setCurrentToolOption: (option: ToolOption) => void;
-  selectImage: (image: string) => void;
-  selectBackgroundImage: (image: string) => void;
-  removeBackgroundImage: () => void;
-  undo: () => void;
-  redo: () => void;
-  clear: () => void;
-  save: () => void;
-  scale: number;
-  toolbarPlacement: string;
-};
-
 export type ToolConfig = {
   label: string;
   icon: React.FC;
   type: Tool;
-  labelThunk?: (props: ToolbarProps) => string;
+  labelThunk?: (props: { scale: number }) => string;
   useDropdown?: (config: {
     currentToolOption: ToolOption;
     setCurrentToolOption: (option: ToolOption) => void;

--- a/src/enums/Tool.ts
+++ b/src/enums/Tool.ts
@@ -81,4 +81,36 @@ export type ToolOption = {
       };
 };
 
+export type ToolbarProps = {
+  currentTool: Tool;
+  setCurrentTool: (tool: Tool) => void;
+  currentToolOption: ToolOption;
+  setCurrentToolOption: (option: ToolOption) => void;
+  selectImage: (image: string) => void;
+  selectBackgroundImage: (image: string) => void;
+  removeBackgroundImage: () => void;
+  undo: () => void;
+  redo: () => void;
+  clear: () => void;
+  save: () => void;
+  scale: number;
+  toolbarPlacement: string;
+};
+
+export type ToolConfig = {
+  label: string;
+  icon: React.FC;
+  type: Tool;
+  labelThunk?: (props: ToolbarProps) => string;
+  useDropdown?: (config: {
+    currentToolOption: ToolOption;
+    setCurrentToolOption: (option: ToolOption) => void;
+    setCurrentTool: (tool: Tool) => void;
+    prefixCls: string;
+    selectBackgroundImage?: () => void;
+    removeBackgroundImage?: () => void;
+  }) => JSX.Element;
+  style?: React.CSSProperties;
+}
+
 export default Tool;


### PR DESCRIPTION
We had disabled the tool dropdowns because they were causing issues after we fixed the global styles issue.
This code re-implements these tool dropdowns and makes it so we can use them again.