### PR TITLE
Geekie bugfix

### DIFF
--- a/lib/ImageTool.d.ts
+++ b/lib/ImageTool.d.ts
@@ -7,5 +7,7 @@ export declare type Background = {
 };
 export declare const drawImage: (item: Image, context: CanvasRenderingContext2D, pos: Position, id: string, rerender: () => void) => void;
 export declare const drawBackgroundImage: (item: Image, canvas: HTMLCanvasElement, context: CanvasRenderingContext2D, viewMatrix: number[], id: string, rerender: () => void) => void;
-export declare const onImageComplete: (data: string, canvas: HTMLCanvasElement, viewMatrix: number[], handleCompleteOperation: (tool?: Tool, data?: Image, pos?: Position) => void) => void;
+export declare const onImageComplete: (data: string, canvas: HTMLCanvasElement, viewMatrix: number[], handleCompleteOperation: (tool?: Tool, data?: Image, pos?: Position) => void, options?: {
+    imageSize?: 'contain';
+}) => void;
 export declare const onBackgroundImageComplete: (data: string, canvas: HTMLCanvasElement, viewMatrix: number[], handleCompleteOperation: (tool?: Tool, data?: Image, pos?: Position) => void) => void;

--- a/lib/ImageTool.js
+++ b/lib/ImageTool.js
@@ -47,13 +47,15 @@ var drawBackgroundImage = function drawBackgroundImage(item, canvas, context, vi
       position = pos;
       _cacheBackgroundPosition[item.imageData] = pos;
       drawImage(item, context, position, id, rerender);
+    }, {
+      imageSize: "contain"
     });
   }
 };
 
 exports.drawBackgroundImage = drawBackgroundImage;
 
-var onImageComplete = function onImageComplete(data, canvas, viewMatrix, handleCompleteOperation) {
+var onImageComplete = function onImageComplete(data, canvas, viewMatrix, handleCompleteOperation, options) {
   var image = new Image();
 
   image.onload = function () {
@@ -65,14 +67,41 @@ var onImageComplete = function onImageComplete(data, canvas, viewMatrix, handleC
     var imageHeight = image.height;
     var offsetWidth = canvas.offsetWidth;
     var offsetHeight = canvas.offsetHeight;
-    var pos = (0, _utils.mapClientToCanvas)({
-      clientX: left + (offsetWidth / 2 - imageWidth / 4),
-      clientY: top + (offsetHeight / 2 - imageHeight / 4)
-    }, canvas, viewMatrix);
-    var posEnd = (0, _utils.mapClientToCanvas)({
-      clientX: left + (offsetWidth / 2 + imageWidth / 4),
-      clientY: top + (offsetHeight / 2 + imageHeight / 4)
-    }, canvas, viewMatrix);
+    var imageRatio = imageWidth / imageHeight;
+    var canvasRatio = offsetWidth / offsetHeight;
+    var targetImageWidth = imageWidth;
+    var targetImageHeight = imageHeight;
+    var clientPos = {
+      clientX: 0,
+      clientY: 0
+    };
+    var clientPosEnd = {
+      clientX: 0,
+      clientY: 0
+    };
+
+    if ((options === null || options === void 0 ? void 0 : options.imageSize) == "contain") {
+      if (imageRatio >= canvasRatio) {
+        targetImageWidth = offsetWidth;
+        targetImageHeight = targetImageWidth / imageRatio;
+      } else {
+        targetImageHeight = offsetHeight;
+        targetImageWidth = targetImageHeight * imageRatio;
+      }
+
+      clientPos.clientX = left + (offsetWidth / 2 - targetImageWidth / 2);
+      clientPos.clientY = top + (offsetHeight / 2 - targetImageHeight / 2);
+      clientPosEnd.clientX = left + (offsetWidth / 2 + targetImageWidth / 2);
+      clientPosEnd.clientY = top + (offsetHeight / 2 + targetImageHeight / 2);
+    } else {
+      clientPos.clientX = left + (offsetWidth / 2 - targetImageWidth / 4);
+      clientPos.clientY = top + (offsetHeight / 2 - targetImageHeight / 4);
+      clientPosEnd.clientX = left + (offsetWidth / 2 + targetImageWidth / 4);
+      clientPosEnd.clientY = top + (offsetHeight / 2 + targetImageHeight / 4);
+    }
+
+    var pos = (0, _utils.mapClientToCanvas)(clientPos, canvas, viewMatrix);
+    var posEnd = (0, _utils.mapClientToCanvas)(clientPosEnd, canvas, viewMatrix);
     var posInfo = {
       x: pos[0],
       y: pos[1],

--- a/lib/Layout/Dropdown.d.ts
+++ b/lib/Layout/Dropdown.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="react" />
 declare type Props = {
-    key: string;
     overlay: JSX.Element;
     children: JSX.Element | Array<JSX.Element>;
 };

--- a/lib/Layout/Dropdown.js
+++ b/lib/Layout/Dropdown.js
@@ -27,8 +27,7 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 function Dropdown(props) {
   var children = props.children,
-      overlay = props.overlay,
-      key = props.key;
+      overlay = props.overlay;
 
   var _useState = (0, _react.useState)(false),
       _useState2 = _slicedToArray(_useState, 2),
@@ -55,7 +54,6 @@ function Dropdown(props) {
     position: 'relative'
   };
   return /*#__PURE__*/_react.default.createElement("div", {
-    key: key,
     style: wrapperStyle,
     onMouseEnter: function onMouseEnter() {
       return setDropdownVisible(true);

--- a/lib/ShapeTool.js
+++ b/lib/ShapeTool.js
@@ -151,7 +151,6 @@ var onShapeMouseUp = function onShapeMouseUp(x, y, setCurrentTool, handleComplet
     w: Math.abs(item.end.x - item.start.x),
     h: Math.abs(item.end.y - item.start.y)
   });
-  setCurrentTool(_Tool.default.Select);
   return [item];
 };
 

--- a/lib/SketchPad.js
+++ b/lib/SketchPad.js
@@ -744,7 +744,10 @@ var SketchPad = function SketchPad(props, ref) {
         break;
 
       case _Tool.default.Text:
-        (0, _TextTool.onTextMouseDown)(e, currentToolOption, scale, refInput, refCanvas, intl);
+        (0, _TextTool.onTextMouseDown)({
+          clientX: e.clientX + 2,
+          clientY: e.clientY - currentToolOption.textSize / 2
+        }, currentToolOption, scale, refInput, refCanvas, intl);
         break;
 
       default:
@@ -1104,36 +1107,41 @@ var SketchPad = function SketchPad(props, ref) {
         {
           var textOperation = selectedOperation;
           content = (0, _TextTool.useTextDropdown)({
-            textSize: textOperation.size,
-            textColor: textOperation.color
-          }, function (option) {
-            var data = {
-              color: option.textColor,
-              size: option.textSize
-            };
+            currentToolOption: {
+              textSize: textOperation.size,
+              textColor: textOperation.color
+            },
+            setCurrentToolOption: function setCurrentToolOption(option) {
+              var data = {
+                color: option.textColor,
+                size: option.textSize
+              };
 
-            if (refContext.current && option.textSize !== textOperation.size) {
-              var context = refContext.current; // font size has changed, need to update pos
+              if (refContext.current && option.textSize !== textOperation.size) {
+                var context = refContext.current; // font size has changed, need to update pos
 
-              context.font = "".concat(option.textSize, "px ").concat(_TextTool.font);
-              context.textBaseline = 'alphabetic'; // measureText does not support multi-line
+                context.font = "".concat(option.textSize, "px ").concat(_TextTool.font);
+                context.textBaseline = 'alphabetic'; // measureText does not support multi-line
 
-              var lines = textOperation.text.split('\n');
-              data.pos = _objectSpread(_objectSpread({}, selectedOperation.pos), {}, {
-                w: Math.max.apply(Math, _toConsumableArray(lines.map(function (line) {
-                  return context.measureText(line).width;
-                }))),
-                h: lines.length * option.textSize
-              });
-            }
+                var lines = textOperation.text.split('\n');
+                data.pos = _objectSpread(_objectSpread({}, selectedOperation.pos), {}, {
+                  w: Math.max.apply(Math, _toConsumableArray(lines.map(function (line) {
+                    return context.measureText(line).width;
+                  }))),
+                  h: lines.length * option.textSize
+                });
+              }
 
-            handleCompleteOperation(_Tool.default.Update, {
-              operationId: selectedOperation.id,
-              data: data
-            }); // @ts-ignore
+              handleCompleteOperation(_Tool.default.Update, {
+                operationId: selectedOperation.id,
+                data: data
+              }); // @ts-ignore
 
-            setSelectedOperation(_objectSpread(_objectSpread({}, selectedOperation), data));
-          }, function () {}, intl, prefixCls);
+              setSelectedOperation(_objectSpread(_objectSpread({}, selectedOperation), data));
+            },
+            setCurrentTool: function setCurrentTool() {},
+            prefixCls: prefixCls
+          });
           break;
         }
 
@@ -1198,9 +1206,7 @@ var SketchPad = function SketchPad(props, ref) {
     onTouchStart: onTouchStart,
     onTouchEnd: onTouchEnd,
     onMouseUp: onMouseUp
-  }, /*#__PURE__*/_react.default.createElement("div", {
-    id: "test"
-  }), /*#__PURE__*/_react.default.createElement("canvas", _objectSpread(_objectSpread({
+  }, /*#__PURE__*/_react.default.createElement("canvas", _objectSpread(_objectSpread({
     ref: refCanvas,
     onDoubleClick: onDoubleClick,
     className: "".concat(sketchpadPrefixCls, "-canvas"),

--- a/lib/StrokeTool.css
+++ b/lib/StrokeTool.css
@@ -64,11 +64,12 @@
   border: 1px solid #E9E9E9;
   padding: 1px;
   margin-right: 10px;
-  display: flex;
-  align-items: center;
   cursor: pointer;
   position: relative;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .drawing-board-strokeTool-palette .drawing-board-strokeTool-color .anticon {
   font-size: 10px;

--- a/lib/StrokeTool.js
+++ b/lib/StrokeTool.js
@@ -15,8 +15,6 @@ var _react = _interopRequireDefault(require("react"));
 
 var _Tool = _interopRequireWildcard(require("./enums/Tool"));
 
-var _utils = require("./utils");
-
 var _Icon = _interopRequireDefault(require("./icons/Icon"));
 
 require("./StrokeTool.css");
@@ -115,18 +113,6 @@ function onStrokeMouseUp(setCurrentTool, handleCompleteOperation) {
   var currentTool = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : _Tool.default.Stroke;
 
   if (!stroke) {
-    return;
-  } // click to back to select mode.
-
-
-  if (stroke.points.length < 6) {
-    if (!_utils.isMobileDevice) {
-      setCurrentTool(_Tool.default.Select);
-    }
-
-    handleCompleteOperation();
-    points = [];
-    stroke = null;
     return;
   }
 

--- a/lib/TextTool.css
+++ b/lib/TextTool.css
@@ -67,11 +67,12 @@
   border: 1px solid #E9E9E9;
   padding: 1px;
   margin-right: 10px;
-  display: flex;
-  align-items: center;
   cursor: pointer;
   position: relative;
   overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 .drawing-board-textTool-palette .drawing-board-textTool-color .anticon {
   font-size: 10px;

--- a/lib/TextTool.d.ts
+++ b/lib/TextTool.d.ts
@@ -14,4 +14,9 @@ export declare const onTextMouseDown: (e: {
 export declare const onTextComplete: (refInput: RefObject<HTMLDivElement>, refCanvas: RefObject<HTMLCanvasElement>, viewMatrix: number[], scale: number, handleCompleteOperation: (tool?: Tool, data?: Text, pos?: Position) => void, setCurrentTool: (tool: Tool) => void) => void;
 export declare const font = "\"PingFang SC\", -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Helvetica, \"Hiragino Sans GB\", \"Microsoft YaHei\", SimSun, sans-serif, \"localant\"";
 export declare const drawText: (item: Text, context: CanvasRenderingContext2D, pos: Position) => void;
-export declare const useTextDropdown: (currentToolOption: ToolOption, setCurrentToolOption: (option: ToolOption) => void, setCurrentTool: (tool: Tool) => void, intl: IntlShape, prefixCls: string) => JSX.Element;
+export declare const useTextDropdown: (config: {
+    currentToolOption: ToolOption;
+    setCurrentToolOption: (option: ToolOption) => void;
+    setCurrentTool: (tool: Tool) => void;
+    prefixCls: string;
+}) => JSX.Element;

--- a/lib/TextTool.js
+++ b/lib/TextTool.js
@@ -15,6 +15,8 @@ var _utils = require("./utils");
 
 var _Icon = _interopRequireDefault(require("./icons/Icon"));
 
+var _reactIntl = require("react-intl");
+
 require("./TextTool.css");
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -108,7 +110,6 @@ var onTextComplete = function onTextComplete(refInput, refCanvas, viewMatrix, sc
       color: currentColor,
       size: currentSize
     }, pos);
-    setCurrentTool(_Tool.default.Select);
     currentText = '';
   }
 };
@@ -131,8 +132,13 @@ var drawText = function drawText(item, context, pos) {
 
 exports.drawText = drawText;
 
-var useTextDropdown = function useTextDropdown(currentToolOption, setCurrentToolOption, setCurrentTool, intl, prefixCls) {
-  prefixCls += '-textTool';
+var useTextDropdown = function useTextDropdown(config) {
+  var currentToolOption = config.currentToolOption,
+      setCurrentToolOption = config.setCurrentToolOption,
+      setCurrentTool = config.setCurrentTool,
+      basePrefixCls = config.prefixCls;
+  var intl = (0, _reactIntl.useIntl)();
+  var prefixCls = basePrefixCls + '-textTool';
   return /*#__PURE__*/_react.default.createElement("div", {
     className: "".concat(prefixCls, "-strokeMenu")
   }, /*#__PURE__*/_react.default.createElement("div", {
@@ -147,14 +153,14 @@ var useTextDropdown = function useTextDropdown(currentToolOption, setCurrentTool
         setCurrentToolOption(_objectSpread(_objectSpread({}, currentToolOption), {}, {
           textSize: size
         }));
-        setCurrentTool && setCurrentTool(_Tool.default.Stroke);
+        setCurrentTool && setCurrentTool(_Tool.default.Text);
       },
       onClick: function onClick(evt) {
         evt.stopPropagation();
         setCurrentToolOption(_objectSpread(_objectSpread({}, currentToolOption), {}, {
           textSize: size
         }));
-        setCurrentTool && setCurrentTool(_Tool.default.Stroke);
+        setCurrentTool && setCurrentTool(_Tool.default.Text);
       },
       style: {
         color: size === currentToolOption.textSize ? '#666' : '#ccc'
@@ -179,14 +185,14 @@ var useTextDropdown = function useTextDropdown(currentToolOption, setCurrentTool
         setCurrentToolOption(_objectSpread(_objectSpread({}, currentToolOption), {}, {
           textColor: color
         }));
-        setCurrentTool && setCurrentTool(_Tool.default.Stroke);
+        setCurrentTool && setCurrentTool(_Tool.default.Text);
       },
       onTouchStart: function onTouchStart(evt) {
         evt.stopPropagation();
         setCurrentToolOption(_objectSpread(_objectSpread({}, currentToolOption), {}, {
           textColor: color
         }));
-        setCurrentTool && setCurrentTool(_Tool.default.Stroke);
+        setCurrentTool && setCurrentTool(_Tool.default.Text);
       }
     }, /*#__PURE__*/_react.default.createElement("div", {
       className: "".concat(prefixCls, "-fill"),

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -57,6 +57,8 @@ var _ConfigContext = _interopRequireDefault(require("./ConfigContext"));
 
 var _EnableSketchPadContext = _interopRequireDefault(require("./contexts/EnableSketchPadContext"));
 
+var _TextTool = require("./TextTool");
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function _getRequireWildcardCache(nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
@@ -103,7 +105,8 @@ var useTools = function useTools() {
     }, {
       label: 'umi.block.sketch.text',
       icon: _TextIcon.default,
-      type: _Tool.default.Text
+      type: _Tool.default.Text,
+      useDropdown: _TextTool.useTextDropdown
     }, {
       label: 'umi.block.sketch.image',
       icon: _ImageIcon.default,

--- a/lib/enums/Tool.js
+++ b/lib/enums/Tool.js
@@ -51,13 +51,13 @@ exports.TextSize = TextSize;
 })(TextSize || (exports.TextSize = TextSize = {}));
 
 var defaultToolOption = {
-  strokeSize: strokeSize[1],
+  strokeSize: strokeSize[0],
   strokeColor: strokeColor[0],
   shapeType: ShapeType.Rectangle,
   shapeBorderColor: strokeColor[0],
-  shapeBorderSize: 4,
+  shapeBorderSize: strokeSize[0],
   textColor: strokeColor[0],
-  textSize: TextSize.Default,
+  textSize: TextSize.Small,
   defaultText: {
     id: 'umi.block.sketch.text.placeholder'
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -123,7 +123,12 @@ var Block = function Block(props) {
   var scale = (0, _utils.extract_scale_from_matrix)(viewMatrix);
   (0, _react.useEffect)(function () {
     var keydownHandler = function keydownHandler(evt) {
-      var keyCode = evt.keyCode; // key 'p'
+      var keyCode = evt.keyCode; // prevent shorcut when user input text 
+
+      if (currentTool === _Tool.default.Text) {
+        return;
+      } // key 'p'
+
 
       if (keyCode === 80) {
         setCurrentTool(_Tool.default.Stroke);
@@ -149,7 +154,7 @@ var Block = function Block(props) {
     return function () {
       return removeEventListener('keydown', keydownHandler);
     };
-  }, []);
+  }, [currentTool]);
 
   var renderWithLayout = function renderWithLayout(toolbar, sketchPad) {
     if (toolbarPlacement === 'left' || _utils.isMobileDevice) {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.6",
-    "react-intl": "^3.9.2",
+    "react-intl": "^5.25.1",
     "react-spring": "^8.0.27",
     "react-use-gesture": "^7.0.15",
     "uuid": "^3.3.3"

--- a/src/ImageTool.tsx
+++ b/src/ImageTool.tsx
@@ -63,6 +63,8 @@ export const drawBackgroundImage = (
       position = pos;
       _cacheBackgroundPosition[item.imageData] = pos;
       drawImage(item, context, position, id, rerender);
+    }, {
+      imageSize: "contain"
     });
   }
 };
@@ -72,6 +74,9 @@ export const onImageComplete = (
   canvas: HTMLCanvasElement,
   viewMatrix: number[],
   handleCompleteOperation: (tool?: Tool, data?: Image, pos?: Position) => void,
+  options?: {
+    imageSize?: 'contain'
+  },
 ) => {
   const image = new Image();
 
@@ -82,19 +87,47 @@ export const onImageComplete = (
     const offsetWidth = canvas.offsetWidth;
     const offsetHeight = canvas.offsetHeight;
 
+    const imageRatio = imageWidth / imageHeight;
+    const canvasRatio = offsetWidth / offsetHeight;
+
+    let targetImageWidth = imageWidth;
+    let targetImageHeight = imageHeight;
+
+    const clientPos = {
+      clientX: 0,
+      clientY: 0,
+    }
+    const clientPosEnd = {
+      clientX: 0,
+      clientY: 0,
+    }
+    if (options?.imageSize == "contain") {
+      if (imageRatio >= canvasRatio) {
+        targetImageWidth = offsetWidth;
+        targetImageHeight = targetImageWidth / imageRatio;
+      } else {
+        targetImageHeight = offsetHeight;
+        targetImageWidth = targetImageHeight * imageRatio;
+      }
+
+      clientPos.clientX = left + (offsetWidth / 2 - targetImageWidth / 2);
+      clientPos.clientY = top + (offsetHeight / 2 - targetImageHeight / 2);
+      clientPosEnd.clientX = left + (offsetWidth / 2 + targetImageWidth / 2);
+      clientPosEnd.clientY = top + (offsetHeight / 2 + targetImageHeight / 2);
+    } else {
+      clientPos.clientX = left + (offsetWidth / 2 - targetImageWidth / 4);
+      clientPos.clientY = top + (offsetHeight / 2 - targetImageHeight / 4);
+      clientPosEnd.clientX = left + (offsetWidth / 2 + targetImageWidth / 4);
+      clientPosEnd.clientY = top + (offsetHeight / 2 + targetImageHeight / 4);
+    }
+
     const pos = mapClientToCanvas(
-      {
-        clientX: left + (offsetWidth / 2 - imageWidth / 4),
-        clientY: top + (offsetHeight / 2 - imageHeight / 4),
-      } as MouseEvent<HTMLCanvasElement>,
+      clientPos as MouseEvent<HTMLCanvasElement>,
       canvas,
       viewMatrix,
     );
     const posEnd = mapClientToCanvas(
-      {
-        clientX: left + (offsetWidth / 2 + imageWidth / 4),
-        clientY: top + (offsetHeight / 2 + imageHeight / 4),
-      } as MouseEvent<HTMLCanvasElement>,
+      clientPosEnd as MouseEvent<HTMLCanvasElement>,
       canvas,
       viewMatrix,
     );

--- a/src/Layout/Dropdown.tsx
+++ b/src/Layout/Dropdown.tsx
@@ -1,13 +1,12 @@
 import React, { CSSProperties, MouseEventHandler, useState } from "react";
 
 type Props = {
-  key: string;
   overlay: JSX.Element;
   children: JSX.Element | Array<JSX.Element>;
 };
 
 function Dropdown(props: Props) {
-  const { children, overlay, key } = props;
+  const { children, overlay } = props;
   const [isDropdownVisible, setDropdownVisible] = useState(false);
 
   // This code will prevent accidentally drawing under the dropdown when you are
@@ -29,7 +28,6 @@ function Dropdown(props: Props) {
 
   return (
     <div
-      key={key}
       style={wrapperStyle}
       onMouseEnter={() => setDropdownVisible(true)}
       onMouseLeave={() => setDropdownVisible(false)}
@@ -37,7 +35,6 @@ function Dropdown(props: Props) {
       {children}
       {isDropdownVisible ? settingMenu : null}
     </div>
-
   );
 }
 

--- a/src/ShapeTool.tsx
+++ b/src/ShapeTool.tsx
@@ -170,8 +170,6 @@ export const onShapeMouseUp = (
     h: Math.abs(item.end.y - item.start.y),
   });
 
-  setCurrentTool(Tool.Select);
-
   return [item];
 };
 

--- a/src/SketchPad.tsx
+++ b/src/SketchPad.tsx
@@ -1155,12 +1155,12 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
         break;
       case Tool.Text: {
         const textOperation: Text = selectedOperation as Text;
-        content = useTextDropdown(
-          {
+        content = useTextDropdown({
+          currentToolOption: {
             textSize: textOperation.size,
             textColor: textOperation.color,
           } as ToolOption,
-          (option: ToolOption) => {
+          setCurrentToolOption: (option: ToolOption) => {
             const data: Partial<Operation> = {
               color: option.textColor,
               size: option.textSize,
@@ -1189,10 +1189,9 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
             // @ts-ignore
             setSelectedOperation({ ...selectedOperation, ...data });
           },
-          () => { },
-          intl,
+          setCurrentTool: () => { },
           prefixCls,
-        );
+        });
         break;
       }
       default:

--- a/src/SketchPad.tsx
+++ b/src/SketchPad.tsx
@@ -1257,7 +1257,6 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
       onTouchEnd={onTouchEnd}
       onMouseUp={onMouseUp}
     >
-      <div id="test"></div>
       <canvas
         ref={refCanvas}
         onDoubleClick={onDoubleClick}

--- a/src/SketchPad.tsx
+++ b/src/SketchPad.tsx
@@ -485,8 +485,8 @@ const useResizeHandler = (
     };
   } else
     return {
-      onMouseMove: () => {},
-      onMouseUp: () => {},
+      onMouseMove: () => { },
+      onMouseUp: () => { },
       resizer: null,
     };
 };
@@ -783,7 +783,10 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
         onShapeMouseDown(x, y, currentToolOption);
         break;
       case Tool.Text:
-        onTextMouseDown(e, currentToolOption, scale, refInput, refCanvas, intl);
+        onTextMouseDown({
+          clientX: e.clientX + 2,
+          clientY: e.clientY - currentToolOption.textSize / 2
+        }, currentToolOption, scale, refInput, refCanvas, intl);
         break;
       default:
         break;
@@ -1121,7 +1124,7 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
 
             setSelectedOperation({ ...selectedOperation, ...data });
           },
-          setCurrentTool: () => {},
+          setCurrentTool: () => { },
           prefixCls,
         });
         break;
@@ -1146,7 +1149,7 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
 
             setSelectedOperation({ ...selectedOperation, ...data });
           },
-          setCurrentTool: () => {},
+          setCurrentTool: () => { },
           prefixCls,
         });
         break;
@@ -1186,7 +1189,7 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
             // @ts-ignore
             setSelectedOperation({ ...selectedOperation, ...data });
           },
-          () => {},
+          () => { },
           intl,
           prefixCls,
         );

--- a/src/StrokeTool.less
+++ b/src/StrokeTool.less
@@ -83,6 +83,9 @@
     cursor: pointer;
     position: relative;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     .anticon {
       font-size: 10px;

--- a/src/StrokeTool.tsx
+++ b/src/StrokeTool.tsx
@@ -108,20 +108,6 @@ export function onStrokeMouseUp(
     return;
   }
 
-  // click to back to select mode.
-  if (stroke.points.length < 6) {
-    if (!isMobileDevice) {
-      setCurrentTool(Tool.Select);
-    }
-
-    handleCompleteOperation();
-
-    points = [];
-    stroke = null;
-
-    return;
-  }
-
   const item = stroke;
   points = [];
   stroke = null;

--- a/src/TextTool.less
+++ b/src/TextTool.less
@@ -87,6 +87,9 @@
     cursor: pointer;
     position: relative;
     overflow: hidden;
+    display: flex;
+    align-items: center;
+    justify-content: center;
 
     .anticon {
       font-size: 10px;

--- a/src/TextTool.tsx
+++ b/src/TextTool.tsx
@@ -36,7 +36,7 @@ export const onTextMouseDown = (
     const { top, left } = canvas.getBoundingClientRect();
 
     let x = e.clientX - left;
-    let y = e.clientY - top - toolOption.textSize / 2;
+    let y = e.clientY - top;
 
     textarea.style.display = 'block';
     textarea.style.left = x + canvas.offsetLeft + 'px';
@@ -111,7 +111,6 @@ export const onTextComplete = (
     };
 
     handleCompleteOperation(Tool.Text, { text, color: currentColor, size: currentSize }, pos);
-    setCurrentTool(Tool.Select);
     currentText = '';
   }
 };

--- a/src/TextTool.tsx
+++ b/src/TextTool.tsx
@@ -4,6 +4,7 @@ import { IntlShape } from 'react-intl';
 import { RefObject, MouseEvent as ReactMouseEvent } from 'react';
 import { mapClientToCanvas, isMobileDevice } from './utils';
 import Icon from './icons/Icon';
+import { useIntl } from 'react-intl';
 import './TextTool.less';
 
 let currentText = '';
@@ -129,14 +130,22 @@ export const drawText = (item: Text, context: CanvasRenderingContext2D, pos: Pos
   }
 };
 
-export const useTextDropdown = (
+export const useTextDropdown = (config: {
   currentToolOption: ToolOption,
   setCurrentToolOption: (option: ToolOption) => void,
   setCurrentTool: (tool: Tool) => void,
-  intl: IntlShape,
   prefixCls: string,
-) => {
-  prefixCls += '-textTool';
+}) => {
+  const {
+    currentToolOption,
+    setCurrentToolOption,
+    setCurrentTool,
+    prefixCls: basePrefixCls,
+  } = config;
+
+  const intl = useIntl();
+
+  const prefixCls = basePrefixCls + '-textTool';
 
   return (
     <div className={`${prefixCls}-strokeMenu`}>
@@ -149,20 +158,20 @@ export const useTextDropdown = (
                 onTouchStart={evt => {
                   evt.stopPropagation();
                   setCurrentToolOption({ ...currentToolOption, textSize: size });
-                  setCurrentTool && setCurrentTool(Tool.Stroke);
+                  setCurrentTool && setCurrentTool(Tool.Text);
                 }}
                 onClick={evt => {
                   evt.stopPropagation();
                   setCurrentToolOption({ ...currentToolOption, textSize: size });
-                  setCurrentTool && setCurrentTool(Tool.Stroke);
+                  setCurrentTool && setCurrentTool(Tool.Text);
                 }}
                 style={{ color: size === currentToolOption.textSize ? '#666' : '#ccc' }}
               >
                 {size === TextSize.Small
                   ? intl.formatMessage({ id: 'umi.block.sketch.text.size.small' })
                   : size === TextSize.Default
-                  ? intl.formatMessage({ id: 'umi.block.sketch.text.size.default' })
-                  : intl.formatMessage({ id: 'umi.block.sketch.text.size.large' })}
+                    ? intl.formatMessage({ id: 'umi.block.sketch.text.size.default' })
+                    : intl.formatMessage({ id: 'umi.block.sketch.text.size.large' })}
               </div>
             );
           })}
@@ -177,12 +186,12 @@ export const useTextDropdown = (
                 onClick={evt => {
                   evt.stopPropagation();
                   setCurrentToolOption({ ...currentToolOption, textColor: color });
-                  setCurrentTool && setCurrentTool(Tool.Stroke);
+                  setCurrentTool && setCurrentTool(Tool.Text);
                 }}
                 onTouchStart={evt => {
                   evt.stopPropagation();
                   setCurrentToolOption({ ...currentToolOption, textColor: color });
-                  setCurrentTool && setCurrentTool(Tool.Stroke);
+                  setCurrentTool && setCurrentTool(Tool.Text);
                 }}
               >
                 <div className={`${prefixCls}-fill`} style={{ background: color }}></div>

--- a/src/TextTool.tsx
+++ b/src/TextTool.tsx
@@ -36,7 +36,7 @@ export const onTextMouseDown = (
     const { top, left } = canvas.getBoundingClientRect();
 
     let x = e.clientX - left;
-    let y = e.clientY - top;
+    let y = e.clientY - top - toolOption.textSize / 2;
 
     textarea.style.display = 'block';
     textarea.style.left = x + canvas.offsetLeft + 'px';

--- a/src/Toolbar.tsx
+++ b/src/Toolbar.tsx
@@ -23,6 +23,7 @@ import './Toolbar.less';
 import { isMobileDevice } from './utils';
 import ConfigContext from './ConfigContext';
 import EnableSketchPadContext from './contexts/EnableSketchPadContext';
+import { useTextDropdown } from './TextTool';
 
 interface ToolConfig {
   label: string;
@@ -66,6 +67,7 @@ const useTools = () => {
         label: 'umi.block.sketch.text',
         icon: TextIcon,
         type: Tool.Text,
+        useDropdown: useTextDropdown,
       },
       {
         label: 'umi.block.sketch.image',

--- a/src/enums/Tool.ts
+++ b/src/enums/Tool.ts
@@ -53,13 +53,13 @@ export enum TextSize {
 }
 
 export const defaultToolOption = {
-  strokeSize: strokeSize[1],
+  strokeSize: strokeSize[0],
   strokeColor: strokeColor[0],
   shapeType: ShapeType.Rectangle,
   shapeBorderColor: strokeColor[0],
-  shapeBorderSize: 4,
+  shapeBorderSize: strokeSize[0],
   textColor: strokeColor[0],
-  textSize: TextSize.Default,
+  textSize: TextSize.Small,
   defaultText: {
     id: 'umi.block.sketch.text.placeholder',
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -92,6 +92,12 @@ const Block: React.FC<BlockProps> = (props) => {
   useEffect(() => {
     const keydownHandler = (evt: KeyboardEvent) => {
       const { keyCode } = evt;
+
+      // prevent shorcut when user input text 
+      if (currentTool === Tool.Text) {
+        return;
+      }
+
       // key 'p'
       if (keyCode === 80) {
         setCurrentTool(Tool.Stroke);
@@ -112,7 +118,7 @@ const Block: React.FC<BlockProps> = (props) => {
     addEventListener('keydown', keydownHandler);
 
     return () => removeEventListener('keydown', keydownHandler);
-  }, []);
+  }, [currentTool]);
 
   const renderWithLayout = (toolbar: React.ReactElement, sketchPad: React.ReactElement) => {
     if (toolbarPlacement === 'left' || isMobileDevice) {


### PR DESCRIPTION
- Background image should occupy the maximum size possible in the canvas. It must preserve its original dimensions. Then it should fit canvas (X,Y)
- The default value of pencil, shape and text tools should be small and not normal value.
- When using the text tool, position the text box exactly where the user chooses. Today positions a few pixels below.
- If I just click when using the pencil tool, it de-selects the tool instead of making a point.
- Whenever I'm using a tool (pencil, eraser, shapes, or text) at the end of the first use it switches to the selection tool. Always keep the chosen tool and do not switch to the select tool.
- Whenever I'm using a tool (pencil, eraser, shapes, or text) at the end of the first use it switches to the selection tool. Always keep the chosen tool and do not switch to the select tool.
- When selecting the text tool, when hovering, the font size and colors options do not appear (when hovering over the pencil and shapes tool it appears). Text tool should have the same behavior as pencil and shape tool. Add the dropdown on the text button.
- When using the text tool, typing the letters "O" or "R" switches to shape tool. If I move the cursor, a shape appears. Removing keyboard shortcuts would work.